### PR TITLE
[#23] README: add a toc + some links to Ocaml tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # Toml (OCaml parser for TOML)
-[![Build Status](https://travis-ci.org/sagotch/To.ml.png?branch=master)](https://travis-ci.org/sagotch/To.ml)
-[![Coverage Status](https://coveralls.io/repos/sagotch/To.ml/badge.png)](https://coveralls.io/r/sagotch/To.ml)
+
+[![Build Status](https://travis-ci.org/mackwic/To.ml.png?branch=master)](https://travis-ci.org/mackwic/To.ml)
+[![Coverage
+Status](https://coveralls.io/repos/mackwic/To.ml/badge.png?branch=master)](https://coveralls.io/r/mackwic/To.ml?branch=master)
 
 OCaml parser for TOML [(Tom's Obvious Minimal Language)](https://github.com/mojombo/toml) v0.2.0.
+
+## Table of contents
+
+- [A foreword to beginners](#a-foreword-to-beginners)
+- [Dependencies](#dependencies)
+- [Install](#install)
+- [Usage](#usage)
+- [Reading Toml data](#reading-toml-data)
+- [Writing Toml data](#writing-toml-data)
+- [Limitations](#limitations)
+
+## A foreword to beginners
+
+New to Ocaml ? Don't worry, just check theses links to begin with:
+
+- [Play with Ocaml online and discover the language](http://try.ocamlpro.com/)
+- [See Ocaml code examples](http://rosettacode.org/wiki/Category:OCaml)
+- [The full official list of Ocaml tutorials](http://ocaml.org/learn/tutorials/)
+- Recommanded tools:
+    - [Ocaml Package Manager](https://opam.ocaml.org) (also install compilers)
+    - [Ocaml IDE](http://www.algo-prog.info/ocaide/install.php)
+    - [Ocaml Interpretor](https://github.com/diml/utop)
 
 ## Dependencies
 
@@ -16,7 +40,7 @@ generate code coverage summary.
 
 * Via Opam: `opam install toml`
 * From source:
-```
+```bash
 git clone https://github.com/sagotch/To.ml
 cd To.ml
 make build
@@ -28,8 +52,14 @@ make install may need sudo.
 
 `open Toml` in your file(s), and link toml library when compiling. For
 instance, using ocamlbuild:
-```
+```bash
 ocamlbuild -use-ocamlfind -package toml foo.byte
+```
+or using an ocaml toplevel (like utop):
+```bash
+$ utop
+utop # #use "topfind";;
+utop # #require "toml";; (* now you can use the Toml module *)
 ```
 
 ### Reading Toml data


### PR DESCRIPTION
Links and content open to discussion.

Also, change the badges reference to `mackwic/To.ml`