### PR TITLE
remove useless dependency on menhir as a lib (fix #35), fix issues

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -39,8 +39,8 @@ Library toml
     BuildDepends: str
     FindlibName: toml
     Install: true
-    InternalModules: TomlInternal
-    Modules: Toml, TomlLexer, TomlParser, TomlPrinter, TomlUnicode
+    InternalModules: TomlInternal, TomlLexer, TomlParser, TomlPrinter, TomlUnicode
+    Modules: Toml
     Path: src/
     XMETAEnable: true
     XMETADescription: Toml parser

--- a/_oasis
+++ b/_oasis
@@ -36,15 +36,14 @@ XStdFilesAUTHORS: true
 # Main Library                                                               #
 ###############################################################################
 Library toml
-    BuildDepends: str, menhirLib
+    BuildDepends: str
     FindlibName: toml
     Install: true
     InternalModules: TomlInternal
-    Modules: Toml
+    Modules: Toml, TomlLexer, TomlParser, TomlPrinter, TomlUnicode
     Path: src/
     XMETAEnable: true
     XMETADescription: Toml parser
-    XMETARequires: str, menhir
 
 ###############################################################################
 # Test executables                                                            #

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: f8ba012723f04737ea7ecacffc503ddb)
+# DO NOT EDIT (digest: 8b4b5eeffa498d87474f03f8265b6e6a)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -16,16 +16,13 @@ true: annot, bin_annot
 "_darcs": not_hygienic
 # Library toml
 "src/toml.cmxs": use_toml
-<src/*.ml{,i,y}>: package(menhirLib)
 <src/*.ml{,i,y}>: package(str)
 # Executable test_toml
 "tests/suite.byte": package(bisect)
-"tests/suite.byte": package(menhirLib)
 "tests/suite.byte": package(oUnit)
 "tests/suite.byte": package(str)
 "tests/suite.byte": use_toml
 <tests/*.ml{,i,y}>: package(bisect)
-<tests/*.ml{,i,y}>: package(menhirLib)
 <tests/*.ml{,i,y}>: package(oUnit)
 <tests/*.ml{,i,y}>: package(str)
 <tests/*.ml{,i,y}>: use_toml


### PR DESCRIPTION
There were some problems trying to load the library (dependency on menhir, which isn't a lib; modules were missing). Did you try to use the library?