### PR TITLE
Remove dependency for 'str' from the META file

### DIFF
--- a/src/META
+++ b/src/META
@@ -2,7 +2,7 @@
 # DO NOT EDIT (digest: 85a51678cdb9fb6891e57db98993c828)
 version = "4.0.0"
 description = "Toml parser"
-requires = "str unix ISO8601"
+requires = "unix ISO8601"
 archive(byte) = "toml.cma"
 archive(byte, plugin) = "toml.cma"
 archive(native) = "toml.cmxa"


### PR DESCRIPTION
It appears toml doesn't use the str package, yet the META file declares a dependency for it. This removes the dependency.