### PR TITLE
cconv decoder

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -3,5 +3,6 @@ S tests
 PKG oUnit
 PKG ISO8601
 PKG bisect
+PKG cconv
 B _build/src
 B _build/tests

--- a/README.md
+++ b/README.md
@@ -136,6 +136,33 @@ utop # Toml.Printer.string_of_table toml_data';;
 
 ```
 
+### PPX support
+
+To.ml supports ppx via [cconv](https://github.com/c-cube/cconv)
+
+``` ocaml
+utop # #require "cconv.ppx";;
+utop # #require "toml.cconv";;
+
+utop # type t = { ints : int list; string : string } [@@deriving cconv];;
+type t = { ints : int list; string : string; }                                                  
+val encode : t CConv.Encode.encoder = {CConv.Encode.emit = <fun>}                               
+val decode : t CConv.Decode.decoder =
+  {CConv.Decode.dec =
+    {CConv.Decode.accept_unit = <fun>; accept_bool = <fun>;
+     accept_float = <fun>; accept_int = <fun>; accept_int32 = <fun>;
+     accept_int64 = <fun>; accept_nativeint = <fun>; accept_char = <fun>;
+     accept_string = <fun>; accept_list = <fun>; accept_option = <fun>;
+     accept_record = <fun>; accept_tuple = <fun>; accept_sum = <fun>}}
+
+utop # let toml = Toml.Parser.(from_string "ints = [1, 2]\nstring = \"string value\"\n"
+                               |> unsafe);;
+val toml : TomlTypes.table = <abstr>
+
+utop # TomlCconv.decode_exn decode toml;;
+- : t = {ints = [1; 2]; string = "string value"}
+```
+
 ## Limitations
 
 * Keys don't quite follow the Toml standard. Both section keys (eg,

--- a/_oasis
+++ b/_oasis
@@ -13,6 +13,7 @@ Authors:
     Julien Sagot
     Emmanuel Surleau
     mackwic
+    Andrew Rudenko
 Maintainers: the TOML ML <contact@toml.epimeros.org>
 Homepage: http://mackwic.github.io/To.ml/
 
@@ -45,6 +46,20 @@ Library toml
     XMETAEnable: true
     XMETADescription: Toml parser
     XMETARequires: str, unix, ISO8601
+
+###############################################################################
+# Cconv encoder / decoder                                                     #
+###############################################################################
+Library toml_cconv
+    BuildDepends: cconv, toml
+    FindlibParent: toml
+    FindlibName: cconv
+    Install: true
+    Modules: TomlCconv
+    Path: cconv/
+    XMETAEnable: true
+    XMETADescription: cconv encoder/decoder for Toml parser
+    XMETARequires: cconv, toml
 
 ###############################################################################
 # Test executables                                                            #

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 2d380aa0596cbc947763c8e1160b2a04)
+# DO NOT EDIT (digest: 85e9eb649b7e8d570ef59eb5fa2a616b)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -19,6 +19,13 @@ true: annot, bin_annot
 <src/*.ml{,i,y}>: package(ISO8601)
 <src/*.ml{,i,y}>: package(str)
 <src/*.ml{,i,y}>: package(unix)
+# Library toml_cconv
+"cconv/toml_cconv.cmxs": use_toml_cconv
+<cconv/*.ml{,i,y}>: package(ISO8601)
+<cconv/*.ml{,i,y}>: package(cconv)
+<cconv/*.ml{,i,y}>: package(str)
+<cconv/*.ml{,i,y}>: package(unix)
+<cconv/*.ml{,i,y}>: use_toml
 # Executable test_toml
 "tests/suite.byte": package(ISO8601)
 "tests/suite.byte": package(bisect)

--- a/cconv/tomlCconv.ml
+++ b/cconv/tomlCconv.ml
@@ -1,0 +1,48 @@
+type t = [
+  | `Int of int
+  | `Float of float
+  | `String of string
+  | `Bool of bool
+  | `List of t list
+  | `Assoc of (string * t) list]
+
+open TomlTypes
+
+let rec of_toml_table v : t =
+  let f (k, v) = (TomlTypes.Table.Key.to_string k, of_toml_value v) in
+  let pairs = List.map f (TomlTypes.Table.bindings v) in
+  `Assoc pairs
+and of_toml_value = function
+  | TBool b -> `Bool b
+  | TInt i -> `Int i
+  | TFloat f -> `Float f
+  | TString s -> `String s
+  | TDate f -> `Float f
+  | TArray a -> `List (of_toml_array a)
+  | TTable t -> of_toml_table t
+and of_toml_array = function
+  | NodeEmpty -> []
+  | NodeBool bs -> List.map (fun v -> `Bool v) bs
+  | NodeInt is -> List.map (fun v -> `Int v) is
+  | NodeFloat fs -> List.map (fun v -> `Float v) fs
+  | NodeString ss -> List.map (fun v -> `String v) ss
+  | NodeDate fs -> List.map (fun v -> `Float v) fs
+  | NodeArray arrs -> List.map (fun v -> `List (of_toml_array v)) arrs
+  | NodeTable ts -> List.map (fun v -> (of_toml_table v)) ts
+
+let source =
+  let module D = CConv.Decode in
+  let rec src = {
+    D.emit = fun dec (x:t) -> match x with
+      | `Bool b -> dec.D.accept_bool src b
+      | `Int i -> dec.D.accept_int src i
+      | `Float f -> dec.D.accept_float src f
+      | `String s -> dec.D.accept_string src s
+      | `List l -> dec.D.accept_list src l
+      | `Assoc l -> dec.D.accept_record src l
+    } in
+  src
+
+let decode dec x = CConv.decode source dec (of_toml_table x)
+
+let decode_exn dec x = CConv.decode_exn source dec (of_toml_table x)

--- a/cconv/tomlCconv.mli
+++ b/cconv/tomlCconv.mli
@@ -1,0 +1,2 @@
+val decode : 'a CConv.Decode.decoder -> TomlTypes.value TomlTypes.Table.t -> 'a CConv.or_error
+val decode_exn : 'a CConv.Decode.decoder -> TomlTypes.value TomlTypes.Table.t -> 'a

--- a/opam
+++ b/opam
@@ -4,7 +4,7 @@ available: [ ocaml-version >= "4.01.0" ]
 
 version: "4.0.0"
 
-authors: [ "Julien Sagot" "Emmanuel Surleau" "mackwic" ]
+authors: [ "Julien Sagot" "Emmanuel Surleau" "mackwic" "Andrew Rudenko"]
 
 maintainer: "support@toml.epimeros.org"
 
@@ -18,6 +18,8 @@ install: [ [ make "install" ] ]
 remove: [ "ocamlfind" "remove" "toml" ]
 
 depends: [ "ocamlfind" "menhir" "ISO8601" ]
+
+depopts: [ "cconv" ]
 
 bug-reports: "https://github.com/mackwic/To.ml/issues"
 

--- a/setup.ml
+++ b/setup.ml
@@ -6912,7 +6912,8 @@ let setup_t =
           license_file = Some "LICENCE";
           copyrights = [];
           maintainers = ["the TOML ML <contact@toml.epimeros.org>"];
-          authors = ["Julien Sagot\nEmmanuel Surleau\nmackwic"];
+          authors =
+            ["Julien Sagot\nEmmanuel Surleau\nmackwic\nAndrew Rudenko"];
           homepage = Some "http://mackwic.github.io/To.ml/";
           synopsis = "pure OCaml library for TOML v0.4.0";
           description =

--- a/src/META
+++ b/src/META
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 85a51678cdb9fb6891e57db98993c828)
+# DO NOT EDIT (digest: 17be49d4ab6e3d254de2de4d02156d52)
 version = "4.0.0"
 description = "Toml parser"
 requires = "str unix ISO8601"
@@ -8,5 +8,15 @@ archive(byte, plugin) = "toml.cma"
 archive(native) = "toml.cmxa"
 archive(native, plugin) = "toml.cmxs"
 exists_if = "toml.cma"
+package "cconv" (
+ version = "4.0.0"
+ description = "cconv encoder/decoder for Toml parser"
+ requires = "cconv toml"
+ archive(byte) = "toml_cconv.cma"
+ archive(byte, plugin) = "toml_cconv.cma"
+ archive(native) = "toml_cconv.cmxa"
+ archive(native, plugin) = "toml_cconv.cmxs"
+ exists_if = "toml_cconv.cma"
+)
 # OASIS_STOP
 


### PR DESCRIPTION
Cconv decoder (inefficient). With it, it's possible to use cconv.ppx to directly decode toml to OCaml's structures. Example:

``` ocaml
type t = { a : int; b : int [@default 5] } [@@deriving cconv];;

let toml = match Toml.Parser.from_string "a = 20" with `Ok v -> v;;

TomlCconv.decode_exn decode toml;;
- : t = {a = 20; b = 5}
```

Relevant issue: #25 
